### PR TITLE
Allow tokens extract

### DIFF
--- a/internal/platform/http/middleware.go
+++ b/internal/platform/http/middleware.go
@@ -8,6 +8,7 @@ func CorsMiddleware(next http.Handler) http.Handler {
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS, PATCH, DELETE, PUT")
 		w.Header().Set("Access-Control-Allow-Headers", "*")
 		w.Header().Set("Access-Control-Allow-Credentials", "false")
+		w.Header().Set("Access-Control-Expose-Headers", "X-Llm-Checker-Access-Token, X-Llm-Checker-Refresh-Token")
 
 		if r.Method == "OPTIONS" {
 			w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
We need it to allow browsers extract headers except from basics for use tokens in Response object